### PR TITLE
fixed nav not showing mobile hamburger correctly on different size

### DIFF
--- a/src/components/Layout/Layout.Container.tsx
+++ b/src/components/Layout/Layout.Container.tsx
@@ -356,6 +356,20 @@ const MobileHamburger = styled.button`
     display: none;
     visibility: hidden;
   `}
+  	${media.desktop`
+    display: none;
+    visibility: hidden;
+	`}
+
+	${media.tablet`
+    display: block;
+    visibility: visible;
+	`}
+	${media.phone`
+    display: block;
+    visibility: visible;
+	`}
+
 
   @media screen and (min-height: 800px) {
     top: 48px;


### PR DESCRIPTION

<img width="944" alt="Screen Shot 2019-12-24 at 11 42 10 AM" src="https://user-images.githubusercontent.com/6353587/71392317-8cca8100-2642-11ea-8fda-dd2efe4fd621.png">
<img width="937" alt="Screen Shot 2019-12-24 at 11 41 45 AM" src="https://user-images.githubusercontent.com/6353587/71392318-8cca8100-2642-11ea-8254-59146fc8ea53.png">

specifying the style for each different size of devices fixed the issue